### PR TITLE
Fix project name inside the config

### DIFF
--- a/refcell/rebar.config
+++ b/refcell/rebar.config
@@ -6,5 +6,5 @@
 
 {shell, [
   % {config, "config/sys.config"},
-    {apps, [ra_examples]}
+    {apps, [refcell]}
 ]}.

--- a/refcell/src/refcell.app.src
+++ b/refcell/src/refcell.app.src
@@ -1,0 +1,15 @@
+{application, refcell,
+ [{description, "An OTP library"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {maintainers, []},
+  {licenses, ["Apache 2.0"]},
+  {links, []}
+]}.


### PR DESCRIPTION
the rebar.config used the `ra_examples` name,
and the app project file was missing.